### PR TITLE
Delete short config used by starport serve

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,9 +1,0 @@
-version: 1
-accounts:
-  - name: user1
-    coins: ["1000token", "100000000stake"]
-  - name: user2
-    coins: ["500token"]
-validator:
-  name: user1
-  staked: "100000000stake"


### PR DESCRIPTION
We don't need this config file anymore, as the `starport serve` command is not used.

ref: #2 