### PR TITLE
Generate a `MsgWirePayForMessage` via CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/tendermint/tm-db v0.6.3
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 // indirect
+	golang.org/x/sys v0.0.0-20210223095934-7937bea0104d // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	google.golang.org/genproto v0.0.0-20210207032614-bba0dbe2a9ea
 	google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 h1:SgQ6LNaYJU0JIuEHv9+s6EbhSCwYeAf5Yvj6lpYlqAE=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210223095934-7937bea0104d h1:u0GOGnBJ3EKE/tNqREhhGiCzE9jFXydDo2lf7hOwGuc=
+golang.org/x/sys v0.0.0-20210223095934-7937bea0104d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/x/lazyledgerapp/client/cli/payformessage.go
+++ b/x/lazyledgerapp/client/cli/payformessage.go
@@ -47,7 +47,7 @@ func CmdCreatePayForMessage() *cobra.Command {
 			// decode the message
 			message, err := hex.DecodeString(args[1])
 			if err != nil {
-				return fmt.Errorf("failure to decode hex message: %s", err)
+				return fmt.Errorf("failure to decode hex message: %w", err)
 			}
 
 			// create the PayForMessage

--- a/x/lazyledgerapp/client/cli/payformessage.go
+++ b/x/lazyledgerapp/client/cli/payformessage.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"encoding/hex"
+	"errors"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/lazyledger/lazyledger-app/x/lazyledgerapp/types"
+	"github.com/spf13/cobra"
+)
+
+// CmdCreatePayForMessage returns a cobra command that uses the key ring backend
+// and locally running node to create and broadcast a new WirePayForMessage
+// transaction.
+func CmdCreatePayForMessage() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "payForMessage [hexNamespace] [hexMessage]",
+		Short: "Creates a new WirePayForMessage",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			// get the account name
+			accName := clientCtx.GetFromName()
+			if accName == "" {
+				return errors.New("no account name provided, please use the --from flag")
+			}
+
+			// get info on the key
+			keyInfo, err := clientCtx.Keyring.Key(accName)
+			if err != nil {
+				return err
+			}
+
+			// decode the namespace
+			namespace, err := hex.DecodeString(args[0])
+			if err != nil {
+				return err
+			}
+
+			// decode the message
+			message, err := hex.DecodeString(args[1])
+			if err != nil {
+				return err
+			}
+
+			// create the PayForMessage
+			pfmMsg, err := types.NewMsgWirePayForMessage(
+				namespace,
+				message,
+				keyInfo.GetPubKey().Bytes(),
+				&types.TransactionFee{}, // transaction fee is not yet used
+				types.SquareSize,
+			)
+			if err != nil {
+				return err
+			}
+
+			// sign the PayForMessage's ShareCommitments
+			err = pfmMsg.SignShareCommitments(accName, clientCtx.Keyring)
+			if err != nil {
+				return err
+			}
+
+			// run message checks
+			if err = pfmMsg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), pfmMsg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/lazyledgerapp/client/cli/payformessage.go
+++ b/x/lazyledgerapp/client/cli/payformessage.go
@@ -41,7 +41,7 @@ func CmdCreatePayForMessage() *cobra.Command {
 			// decode the namespace
 			namespace, err := hex.DecodeString(args[0])
 			if err != nil {
-				return fmt.Errorf("failure to decode hex namespace: %s", err)
+				return fmt.Errorf("failure to decode hex namespace: %w", err)
 			}
 
 			// decode the message

--- a/x/lazyledgerapp/client/cli/payformessage.go
+++ b/x/lazyledgerapp/client/cli/payformessage.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -40,13 +41,13 @@ func CmdCreatePayForMessage() *cobra.Command {
 			// decode the namespace
 			namespace, err := hex.DecodeString(args[0])
 			if err != nil {
-				return err
+				return fmt.Errorf("failure to decode hex namespace: %s", err)
 			}
 
 			// decode the message
 			message, err := hex.DecodeString(args[1])
 			if err != nil {
-				return err
+				return fmt.Errorf("failure to decode hex message: %s", err)
 			}
 
 			// create the PayForMessage

--- a/x/lazyledgerapp/client/cli/tx.go
+++ b/x/lazyledgerapp/client/cli/tx.go
@@ -20,7 +20,7 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	// this line is used by starport scaffolding # 1
+	cmd.AddCommand(CmdCreatePayForMessage())
 
 	return cmd
 }

--- a/x/lazyledgerapp/keeper/msg_server.go
+++ b/x/lazyledgerapp/keeper/msg_server.go
@@ -1,8 +1,20 @@
 package keeper
 
-import "github.com/lazyledger/lazyledger-app/x/lazyledgerapp/types"
+import (
+	"context"
+
+	"github.com/lazyledger/lazyledger-app/x/lazyledgerapp/types"
+)
 
 var _ types.MsgServer = msgServer{}
+
+// MsgServer is the server API for Msg service.
+type MsgServer interface {
+	// PayForMessage allows the user to post data to made be available.
+	PayForMessage(context.Context, *types.MsgWirePayForMessage) (*types.MsgPayForMessageResponse, error)
+	// PayForMessage allows the user to post data to made be available.
+	SignedTransactionDataPayForMessage(context.Context, *types.SignedTransactionDataPayForMessage) (*types.SignedTransactionDataPayForMessageResponse, error)
+}
 
 type msgServer struct {
 	Keeper
@@ -10,6 +22,6 @@ type msgServer struct {
 
 // NewMsgServerImpl returns an implementation of the bank MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) MsgServer {
 	return &msgServer{Keeper: keeper}
 }

--- a/x/lazyledgerapp/types/payformessage.go
+++ b/x/lazyledgerapp/types/payformessage.go
@@ -32,6 +32,7 @@ var _ sdk.Msg = &MsgWirePayForMessage{}
 // Note that the share commitments generated still need to be signed using the Sign
 // method
 func NewMsgWirePayForMessage(namespace, message, pubK []byte, fee *TransactionFee, sizes ...uint64) (*MsgWirePayForMessage, error) {
+	message = PadMessage(message)
 	out := &MsgWirePayForMessage{
 		Fee:                    fee,
 		Nonce:                  0,
@@ -166,7 +167,7 @@ func (msg *MsgWirePayForMessage) GetCommitmentSignBytes(k uint64) ([]byte, error
 // to create a new SignedTransactionDataPayForMessage
 func (msg *MsgWirePayForMessage) SignedTransactionDataPayForMessage(k uint64) (*SignedTransactionDataPayForMessage, error) {
 	// add padding to message if necessary
-	msg.Message = PadMessage(msg.Message)
+	msg.padMessage()
 
 	// create the commitment using the padded message
 	commit, err := CreateCommitment(k, msg.MessageNameSpaceId, msg.Message)
@@ -185,6 +186,16 @@ func (msg *MsgWirePayForMessage) SignedTransactionDataPayForMessage(k uint64) (*
 		MessageShareCommitment: commit,
 	}
 	return &sTxMsg, nil
+}
+
+// padMessage adds padding to a message while also changing the declared message
+// length
+func (msg *MsgWirePayForMessage) padMessage() {
+	msg.Message = PadMessage(msg.Message)
+
+	if uint64(len(msg.Message)) != msg.MessageSize {
+		msg.MessageSize = uint64(msg.MessageSize)
+	}
 }
 
 ///////////////////////////////////////

--- a/x/lazyledgerapp/types/payformessage.go
+++ b/x/lazyledgerapp/types/payformessage.go
@@ -166,9 +166,6 @@ func (msg *MsgWirePayForMessage) GetCommitmentSignBytes(k uint64) ([]byte, error
 // SignedTransactionDataPayForMessage use the data in the MsgWirePayForMessage
 // to create a new SignedTransactionDataPayForMessage
 func (msg *MsgWirePayForMessage) SignedTransactionDataPayForMessage(k uint64) (*SignedTransactionDataPayForMessage, error) {
-	// add padding to message if necessary
-	msg.padMessage()
-
 	// create the commitment using the padded message
 	commit, err := CreateCommitment(k, msg.MessageNameSpaceId, msg.Message)
 	if err != nil {
@@ -186,16 +183,6 @@ func (msg *MsgWirePayForMessage) SignedTransactionDataPayForMessage(k uint64) (*
 		MessageShareCommitment: commit,
 	}
 	return &sTxMsg, nil
-}
-
-// padMessage adds padding to a message while also changing the declared message
-// length
-func (msg *MsgWirePayForMessage) padMessage() {
-	msg.Message = PadMessage(msg.Message)
-
-	if uint64(len(msg.Message)) != msg.MessageSize {
-		msg.MessageSize = uint64(msg.MessageSize)
-	}
 }
 
 ///////////////////////////////////////

--- a/x/lazyledgerapp/types/payformessage_test.go
+++ b/x/lazyledgerapp/types/payformessage_test.go
@@ -174,6 +174,9 @@ func TestSignShareCommitments(t *testing.T) {
 		&TransactionFee{},
 		SquareSize,
 	)
+	if err != nil {
+		t.Error(err)
+	}
 
 	tests := []test{
 		{

--- a/x/lazyledgerapp/types/tx.pb.go
+++ b/x/lazyledgerapp/types/tx.pb.go
@@ -547,8 +547,6 @@ func (c *msgClient) PayForMessage(ctx context.Context, in *MsgWirePayForMessage,
 type MsgServer interface {
 	// PayForMessage allows the user to post data to made be available.
 	PayForMessage(context.Context, *MsgWirePayForMessage) (*MsgPayForMessageResponse, error)
-	// PayForMessage allows the user to post data to made be available.
-	SignedTransactionDataPayForMessage(context.Context, *SignedTransactionDataPayForMessage) (*SignedTransactionDataPayForMessageResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.


### PR DESCRIPTION
## Description
This PR adds a sub command to the cli to generate a `MsgWirePayForMessage` transaction.
```sh
Usage:
  lazyledgerapp tx lazyledgerapp payForMessage [hexNamespace] [hexMessage] [flags]
```
Breaking down the above command, 

- `lazyledgerappd` is the root command for everything lazyledger-app, including starting the node and generating transactions, but of this can change. 
- the `tx` sub-command contains other sub-commands related to generating transactions
- the `lazyledgerapp` sub-command specifies the module that is being used
- `payForMessage` is the sub-command to generate a `MsgWirePayForMessage`

The only necessary inputs are the namespace and the message, where everything else can be optional with sane defaults. 

~~This PR should not be merged until #21 is merged.~~ :heavy_check_mark: 

the full --help message:
```
Usage:
  lazyledgerapp tx lazyledgerapp payForMessage [hexNamespace] [hexMessage] [flags]

Flags:
  -a, --account-number uint      The account number of the signing account (offline mode only)
  -b, --broadcast-mode string    Transaction broadcasting mode (sync|async|block) (default "sync")
      --dry-run                  ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it
      --fees string              Fees to pay along with transaction; eg: 10uatom
      --from string              Name or address of private key with which to sign
      --gas string               gas limit to set per-transaction; set to "auto" to calculate sufficient gas automatically (default 200000)
      --gas-adjustment float     adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored  (default 1)
      --gas-prices string        Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom)
      --generate-only            Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible)
  -h, --help                     help for payForMessage
      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "test")
      --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
      --ledger                   Use a connected Ledger device
      --memo string              Memo to send along with transaction
      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
      --offline                  Offline mode (does not allow any online functionality
  -s, --sequence uint            The sequence number of the signing account (offline mode only)
      --sign-mode string         Choose sign mode (direct|amino-json), this is an advanced feature
      --timeout-height uint      Set a block timeout height to prevent the tx from being committed past a certain height
  -y, --yes                      Skip tx broadcasting prompt confirmation

Global Flags:
      --chain-id string     The network chain ID
      --home string         directory for config and data (default "/home/evan/.lazyledgerapp")
      --log_format string   The logging format (json|plain) (default "plain")
      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --trace               print out full stack trace on errors
```
closes: #31 #35 

## TODO:
- [X] rebase after #21 is merged

---

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Review `Codecov Report` in the comment section below once CI passes
